### PR TITLE
fixing the call to self::$configuration->modules as an object rather then an array.

### DIFF
--- a/core/App.php
+++ b/core/App.php
@@ -286,7 +286,7 @@ class App
         $methodExist = method_exists($this->class, $this->method);
 
         if (!$moduleExist) {
-            $this->output = Router::show404(self::$configuration->modules['defaultModule'] . '/404');
+            $this->output = Router::show404(self::$configuration->modules->defaultModule . '/404');
             return false;
         } elseif (!$classExist) {
             $this->output = Router::show404($this->module . '/404');


### PR DESCRIPTION
it looks like the self::$configuration->modules is an object, not an array so we'll treat it as such when trying to throw a 404