### PR TITLE
Fix broken 404 handling

### DIFF
--- a/core/App.php
+++ b/core/App.php
@@ -286,7 +286,7 @@ class App
         $methodExist = method_exists($this->class, $this->method);
 
         if (!$moduleExist) {
-            $this->output = Router::show404(self::$configuration->modules['defaultModule'] . '/404');
+            $this->output = Router::show404(self::$configuration->modules->defaultModule . '/404');
             return false;
         } elseif (!$classExist) {
             $this->output = Router::show404($this->module . '/404');

--- a/core/App.php
+++ b/core/App.php
@@ -287,7 +287,7 @@ class App
 
         if (!$moduleExist) {
             $this->output = Router::show404(
-                elf::$configuration->modules->defaultModule,
+                self::$configuration->modules->defaultModule,
                 ['errorMessage' => $this->module . ' module could not be found!']
             );
             return false;

--- a/core/App.php
+++ b/core/App.php
@@ -286,13 +286,22 @@ class App
         $methodExist = method_exists($this->class, $this->method);
 
         if (!$moduleExist) {
-            $this->output = Router::show404(self::$configuration->modules->defaultModule . '/404');
+            $this->output = Router::show404(
+                elf::$configuration->modules->defaultModule,
+                ['errorMessage' => $this->module . ' module could not be found!']
+            );
             return false;
         } elseif (!$classExist) {
-            $this->output = Router::show404($this->module . '/404');
+            $this->output = Router::show404(
+                $this->module,
+                ['errorMessage' => $this->class . ' controller could not be found']
+            );
             return false;
         } elseif (!$methodExist) {
-            $this->output = Router::show404($this->module . '/404');
+            $this->output = Router::show404(
+                $this->module,
+                ['errorMessage' => $this->method . ' method in the ' . $this->class . ' controller could not be found']
+            );
             return false;
         }
 

--- a/core/Load.php
+++ b/core/Load.php
@@ -134,13 +134,13 @@ class Load
      * @throws Exception when a view can not be found
      * @throws Exception when a layout can not be found
      */
-    public function view($view = '', $data = [], $layout = 'layout')
+    public function view($view = '', $data = [], $layout = 'layout', $module = null)
     {
-        // This is the same as using globals.
-        $module = App::getConfiguration()->router->module;
+        if(is_null($module)) {
+            $module = App::getConfiguration()->router->module;
+        }
 
         if ($view != '') {
-            // I like how you use spaces here to concat a string
             $file = APP_PATH . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . $module . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR . strtolower($view) . '.php';
             if (file_exists($file)) {
                 $data['view'] = $this->process($file, $data);
@@ -152,7 +152,6 @@ class Load
         }
 
         if ($layout != false) {
-            // but sometimes you don't space em all the same. code style standards are easy to adopt.
             $file = APP_PATH . DIRECTORY_SEPARATOR . 'layouts' . DIRECTORY_SEPARATOR . $module . DIRECTORY_SEPARATOR . strtolower($layout) . '.php';
 
             if (file_exists($file)) {

--- a/core/Router.php
+++ b/core/Router.php
@@ -252,15 +252,14 @@ class Router
      * Set 404 header, and return 404 view contents
      *
      * @access public
+     * @param $module string
+     * @param $data array
      * @return string
      */
-    public static function show404($layout)
+    public static function show404($module, $data = [])
     {
-
         header('HTTP/1.1 404 Not Found');
-
-        return Load::getInstance()->view($layout);
-
+        return Load::getInstance()->view('',$data,'404',$module);
     }
 
     /**


### PR DESCRIPTION
Prior to this quick hack the 404 handling didn't work.   if you called example.com/non-existant-model/anything   you would not get any 404.   

* The 404 was being loaded a view, not a layout.
* There was no explicit module being passed to the view loader so 404's would never work on a non existent model
* There was no throwing of errors or data of any kind to the 404 layout.

Now you get a properly displayed 404 on 
* non existent method
* non existent class (controller)
* non existent controller method
and the 404 lets ya know what actually happened.