### PR TITLE
Patching the string conversion to float when parsing exponent markup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 build/logs/
 build/pdepend/
 build/phpdox/
+build/coverage/
 
 # Composer Sourced Files
 vendor/

--- a/README.MD
+++ b/README.MD
@@ -8,6 +8,18 @@ cd mmvc
 composer install
 ```
 
+## Running Tests ##
+
+Tests can be executed from the command line using Composer, Ant or the PHPUnit executable as follows: 
+
+PHPUnit: `phpunit`
+
+Composer: `composer test`
+
+Ant: `ant phpunit`
+
+The code coverage can be found in the `/build/coverage` folder after running the tests. 
+
 ## Session database schema ##
 ```
 CREATE TABLE `Session` (

--- a/Zewa/Router.php
+++ b/Zewa/Router.php
@@ -141,9 +141,9 @@ class Router
         if (is_numeric($data)) {
             if (is_int($data) || ctype_digit(trim($data, '-'))) {
                 $data = (int)$data;
-            } else if ($data == (string)(float)$data) {
+            } else if ($data === (string)(float)$data) {
                 //@TODO: this needs work.. 9E26 converts to float
-                //$data = (float)$data;
+                $data = (float)$data;
             }
         }
         return $data;

--- a/build.xml
+++ b/build.xml
@@ -80,4 +80,10 @@
         <exec executable="phpdox" dir="${basedir}/build"/>
     </target>
 
+    <target name="test" description="Run test suite and generate PHPUnit code coverage">
+        <delete dir="${basedir}/build/coverage"/>
+        <mkdir dir="${basedir}/build/coverage"/>
+        <exec executable="phpunit"/>
+    </target>
+
 </project>

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,26 @@
       "email": "josh@findsomehelp.com"
     }
   ],
+  "require": {
+    "php": ">=5.4.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "~4.0||~5.0",
+    "scrutinizer/ocular": "~1.1",
+    "squizlabs/php_codesniffer": "~2.3"
+  },
   "autoload": {
     "psr-0": {
       "Zewa\\": "./",
       "Zewa\\Exception\\": "./Exception"
     }
   },
-  "require": {
-    "php": ">=5.4.0"
+  "autoload-dev": {
+    "psr-4": {
+      "Zewa\\Tests\\": "tests"
+    }
   },
-  "require-dev": {}
+  "scripts": {
+    "test": "phpunit"
+  }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Zewa Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">Zewa/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="tap" target="build/logs/report.tap"/>
+        <log type="junit" target="build/logs/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-text" target="build/logs/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+</phpunit>

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -1,0 +1,86 @@
+<?php
+
+
+namespace Zewa\Tests;
+
+use \Zewa\App;
+use \Zewa\Router;
+
+
+class RouterTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * This tests to ensure that all strings that PHP would parse
+     * in to a float given it's exponent notation are NOT converted
+     * to float by the Router's normalize method.
+     *
+     * http://php.net/manual/en/function.is-numeric.php
+     * - Up until PHP 7.0.0 Hexidecimal values are parsed as integers.
+     *
+     * @dataProvider exponentProvider
+     */
+    public function testRouteExponentParamAsString($exponent)
+    {
+        global $_SERVER;
+
+        $_SERVER['REQUEST_URI'] = '/example/home/hello/'.$exponent;
+
+        // Re-Instantiate the Router so it overwrites the params with our new URI
+        $router = new Router();
+        $app    = App::getInstance();
+
+        $routerConfig    = $app->getConfiguration('router');
+        $firstRouteParam = $routerConfig->params[0];
+
+        $this->assertTrue(is_string($firstRouteParam));
+        $this->assertTrue(!is_float($firstRouteParam));
+    }
+
+    /**
+     * If you pass an exponent with a + such as +1.3e3
+     */
+    public function exponentProvider()
+    {
+        return [
+            ['9E26'],
+            ['123e1'],
+            ['-1.3e3'],
+            ['2.1e-5'],
+            ['0x539'],
+        ];
+    }
+
+    /**
+     * This tests to ensure that decimal values passed to the route as a param
+     * are parsed and returned as decimals (as opposed to strings)
+     *
+     * @dataProvider decimalProvider
+     */
+    public function testRouteDecimalParamAsFloat($decimal)
+    {
+        global $_SERVER;
+
+        $_SERVER['REQUEST_URI'] = '/example/home/hello/'.$decimal;
+
+        // Re-Instantiate the Router so it overwrites the params with our new URI
+        $router = new Router();
+        $app    = App::getInstance();
+
+        $routerConfig    = $app->getConfiguration('router');
+        $firstRouteParam = $routerConfig->params[0];
+
+        $this->assertTrue(is_float($firstRouteParam));
+        $this->assertTrue(!is_string($firstRouteParam));
+    }
+
+    public function decimalProvider()
+    {
+        return [
+            ['9.9999'],
+            ['123.0932'],
+            ['0.1'],
+            ['99912.4044'],
+        ];
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+
+// Register Composer Auto Loader
+require __DIR__ . "/../vendor/autoload.php";
+
+// Register Globals
+define('ROOT_PATH', __DIR__ . DIRECTORY_SEPARATOR . "fixtures");
+define('APP_PATH', ROOT_PATH . DIRECTORY_SEPARATOR . 'app');
+define('PUBLIC_PATH', ROOT_PATH . DIRECTORY_SEPARATOR . 'public');
+
+$_SERVER['HTTP_HOST'] = 'zewa.test';
+
+// Create Instance of App
+$app = new \Zewa\App();

--- a/tests/fixtures/app/Config/modules.php
+++ b/tests/fixtures/app/Config/modules.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Modules Configuration File
+ */
+
+return [
+    'defaultModule' => 'example',
+    'example'     => [
+        'defaultController' => 'home',
+        'defaultMethod'     => 'index',
+    ],
+];


### PR DESCRIPTION
This is a real fix for https://github.com/zewadesign/framework/pull/43

I added regression tests for the issue that was parsing strings that looked like floats with exponent markup and fixed the bug itself.  I also tossed in a test (although it'll never be a problem) to make sure hexadecimal strings don't get parsed as integers.  PHP 7.0.0 stops parsing hex strings as int anyway.  

I'd like to add that it seems kind of impossible to test scripts that have `die()` and `exit` littered throughout the code.   I have however written tests that do test this particular float parsing issue. 

And I fixed the bug.  So now strings that look like floats with exponent markup are now passed back as strings and floats that are regular decimal style are parsed as floats and returned as such.