### PR TITLE
updating build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -64,7 +64,7 @@
             <arg value="--report=checkstyle"/>
             <arg value="--report-file=${basedir}/build/logs/checkstyle.xml"/>
             <arg value="--standard=PSR2"/>
-            <arg path="${basedir}"/>
+            <arg path="${basedir}/Zewa"/>
         </exec>
     </target>
 


### PR DESCRIPTION
 so it doesn't try to run our code style check on all the content of Vendor folder

Now `ant phpcs` will run the code style check.  and it happily returns a checkstyle.xml file with the following content: 

`<?xml version="1.0" encoding="UTF-8"?>
<checkstyle version="2.3.1">
</checkstyle>`