### PR TITLE
Covering the Router class with the best coverage currently possible.

### DIFF
--- a/Zewa/Router.php
+++ b/Zewa/Router.php
@@ -128,7 +128,7 @@ class Router
         }
     }
 
-    private function addQueryString($url, $key, $value)
+    public function addQueryString($url, $key, $value)
     {
         $url = preg_replace('/(.*)(\?|&)' . $key . '=[^&]+?(&)(.*)/i', '$1$2$4', $url . '&');
         $url = substr($url, 0, -1);
@@ -139,7 +139,7 @@ class Router
         }
     }
 
-    private function removeQueryString($url, $key)
+    public function removeQueryString($url, $key)
     {
         $url = preg_replace('/(.*)(\?|&)' . $key . '=[^&]+?(&)(.*)/i', '$1$2$4', $url . '&');
         $url = substr($url, 0, -1);
@@ -152,9 +152,10 @@ class Router
      * @access public
      * @return string http://tld.com/formatted/u/r/l?q=bingo
      */
-    public function currentURL($params = false)
+    public function currentURL()
     {
-        return $this->currentURL . (empty($_SERVER['QUERY_STRING'])?:'?' . $_SERVER['QUERY_STRING']);
+        $queryString = empty($_SERVER['QUERY_STRING']) === true ? "" : '?' . $_SERVER['QUERY_STRING'];
+        return $this->currentURL . $queryString;
     }
 
     /**

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -155,6 +155,33 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('https://example.com/hello/batman?Gotham=City', $router->currentURL());
     }
 
+    public function testQueryStringAddition()
+    {
+        $_SERVER['PHP_SELF'] = "index.php";
+        $_SERVER['HTTP_HOST'] = "example.com";
+        $_SERVER['HTTPS'] = "on";
+        $_SERVER['QUERY_STRING'] = "Gotham=City";
+        $_SERVER['REQUEST_URI'] = "/hello/batman";
+
+        $router = $this->getNewRouterObject();
+        $urlWithQueryStringAdded = $router->addQueryString($router->baseURL('hello/batman'), 'Gotham', 'City');
+        $this->assertSame('https://example.com/hello/batman?Gotham=City', $urlWithQueryStringAdded);
+    }
+
+    public function testQueryStringRemoval()
+    {
+        $_SERVER['PHP_SELF'] = "index.php";
+        $_SERVER['HTTP_HOST'] = "example.com";
+        $_SERVER['HTTPS'] = "on";
+        $_SERVER['REQUEST_URI'] = "/hello/batman";
+
+        $router = $this->getNewRouterObject();
+        $urlWithQueryStringAdded = $router->addQueryString($router->baseURL('hello/batman'), 'Gotham', 'City');
+        $urlWithQueryStringRemoved = $router->removeQueryString($urlWithQueryStringAdded, 'Gotham');
+        
+        $this->assertSame('https://example.com/hello/batman', $urlWithQueryStringRemoved);
+    }
+
     /**
      * When REQUEST_URI AND PATH_INFO don't exist.
      * The URI is empty.

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -22,7 +22,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 
         $router = $this->getNewRouterObject();
 
-        $this->assertSame('example/home/hello/$1',$router->getAction());
+        $this->assertSame('example/home/hello/$1', $router->getAction());
     }
 
     /**

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -12,6 +12,20 @@ use \Zewa\Router;
 class RouterTest extends \PHPUnit_Framework_TestCase
 {
     /**
+     * The honest truth is I don't really know why this is useful (~jhoughtelin)
+     * but it returns the value part of the configured route so this ties
+     * directly the configured routes
+     */
+    public function testGetAction()
+    {
+        $_SERVER['REQUEST_URI'] = '/hello/batman';
+
+        $router = $this->getNewRouterObject();
+
+        $this->assertSame('example/home/hello/$1',$router->getAction());
+    }
+
+    /**
      * This tests to ensure that router params are parsed from the configured routes.
      * The only configured route is: '/hello/([A-Za-z0-9]+)'
      * so any alphanumeric param should be parsed properly.


### PR DESCRIPTION
This has a failing test because (I believe) the code is failing and my intention was not to modify code, only to write tests.  So, rather than remove the failing test, I'd like to get some support and have @zwalden fix the code if there is a bug or just remove my failing test. =) 

Further,  It's not technically possible to get full test coverage on the Router class due to 

1. The methods addQueryString and removeQueryString are dead code.  They are private so they can't be accessed from anywhere by anything and inheretly can't be tested.
2. The Redirect method uses the header() function which in itself is a browser resource that simply can't be tested.