### PR TITLE
Security tests

### DIFF
--- a/tests/SecurityTest.php
+++ b/tests/SecurityTest.php
@@ -1,0 +1,122 @@
+<?php
+
+
+namespace Zewa\Tests;
+
+use Zewa\Security;
+
+class SecurityTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNormalizeNullIsNull()
+    {
+        $security = new Security();
+
+        $this->assertTrue(is_null($security->normalize(null)));
+    }
+
+    /**
+     * @dataProvider stringProvider
+     *
+     * @param string $stringValue
+     */
+    public function testStringsAreNotModified($stringValue)
+    {
+        $security = new Security();
+
+        $this->assertSame($stringValue, $security->normalize($stringValue));
+    }
+
+    public function stringProvider()
+    {
+        return [
+            ['string', '012345']
+        ];
+    }
+
+    /**
+     * @dataProvider integerProvider
+     *
+     * @param $integerValue
+     */
+    public function testIntegersAreNotModified($integerValue)
+    {
+        $security = new Security();
+
+        $this->assertSame($integerValue, $security->normalize($integerValue));
+    }
+
+    public function integerProvider()
+    {
+        return [
+            [1, 10, 999, 123456789, -1, -10, -999, -123456789]
+        ];
+    }
+
+    /**
+     * @dataProvider stringIntegerProvider
+     *
+     * @param $stringInteger
+     */
+    public function testStringBecomesInteger($stringInteger)
+    {
+        $security = new Security();
+
+        $integerResult = $security->normalize($stringInteger);
+
+        // It should still be the same value.
+        $this->assertTrue(($stringInteger == $integerResult));
+        // But not the same type
+        $this->assertFalse(($stringInteger === $integerResult));
+        // Because it's now an integer instead of a string.
+        $this->assertTrue(is_integer($integerResult));
+    }
+
+    public function stringIntegerProvider()
+    {
+        return [
+            ["1", "10", "999", "123456789", "-1", "-10", "-999", "-123456789"]
+        ];
+    }
+
+    /**
+     * @dataProvider floatProvider
+     *
+     * @param $floatValue
+     */
+    public function testFloatsAreNotModified($floatValue)
+    {
+        $security = new Security();
+
+        $this->assertSame($floatValue, $security->normalize($floatValue));
+    }
+
+    public function floatProvider()
+    {
+        return [
+            [.023, .3333333333, 1.1, .314, -.023, -.3333333, -1.1, -.314]
+        ];
+    }
+
+    public function testAssocArrayOfStringsAreNotModified()
+    {
+        $assocArrayOfStrings = [
+            'stringKey'    => 'stringValue',
+            'someOtherKey' => 'someOtherValue',
+        ];
+
+        $security = new Security();
+
+        $this->assertSame($assocArrayOfStrings, $security->normalize($assocArrayOfStrings));
+    }
+
+    public function testObjectStaysObject()
+    {
+        $object = new \stdClass();
+        $object->property = 'stringValue';
+        $object->someOtherProperty = 'SomeOtherStringValue';
+
+        $security = new Security();
+
+        $this->assertInstanceOf('stdClass', $security->normalize($object));
+    }
+}

--- a/tests/SecurityTest.php
+++ b/tests/SecurityTest.php
@@ -1,5 +1,11 @@
 <?php
-
+/**
+ * Tests for the Security class.
+ *
+ * As of writing this, the Security class only has one method 'normalize'
+ * which does more than one thing so it should be refactored.  The class
+ * can definitely be refactored without breaking these tests.
+ */
 
 namespace Zewa\Tests;
 


### PR DESCRIPTION
Despite the fact that this class obviously needs to be refactored so the one method in it is broken up so it just does one thing, these tests should not need to be broken to refactor the class.   

I don't understand why this class *normalizes* array keys and object properties names.  If all the normalize method does is turn strings in to integers and floats, doing so, doesn't add up for me.

![2016-12-02_0953](https://cloud.githubusercontent.com/assets/6137941/20842919/7d385894-b876-11e6-883c-2d6684560acc.png)
